### PR TITLE
serial: tty: msm_hs_uart: Fix the compat table

### DIFF
--- a/drivers/tty/serial/msm_serial_hs.c
+++ b/drivers/tty/serial/msm_serial_hs.c
@@ -226,8 +226,8 @@ struct msm_hs_port {
 };
 
 static struct of_device_id msm_hs_match_table[] = {
-	{ .compatible = "qcom,msm-hsuart-v14",
-	},
+	{ .compatible = "qcom,msm-hsuart-v14"},
+	{}
 };
 
 

--- a/drivers/tty/serial/msm_serial_hs_lite.c
+++ b/drivers/tty/serial/msm_serial_hs_lite.c
@@ -157,7 +157,7 @@ static const unsigned int regmap[][UARTDM_LAST] = {
 
 static struct of_device_id msm_hsl_match_table[] = {
 	{	.compatible = "qcom,msm-lsuart-v14",
-		.data = (void *)UARTDM_VERSION_14
+		.data = (void *)UARTDM_VERSION_14,
 	},
 	{}
 };


### PR DESCRIPTION
The compat tables in the msm_hs and msm_hsl drivers do
not have a null terminator structure at the end of the
array. Add them.

Change-Id: I86bd6f92805328099126ef852fca1eb18cbe4670
Signed-off-by: Abhimanyu Kapur abhimany@codeaurora.org
