### PR TITLE
net: udp: Adjust UDP socket state for encapsulation sockets

### DIFF
--- a/net/ipv4/udp.c
+++ b/net/ipv4/udp.c
@@ -1858,14 +1858,18 @@ static void udp4_format_sock(struct sock *sp, struct seq_file *f,
 		int bucket)
 {
 	struct inet_sock *inet = inet_sk(sp);
+	struct udp_sock *up = udp_sk(sp);
 	__be32 dest = inet->inet_daddr;
 	__be32 src  = inet->inet_rcv_saddr;
 	__u16 destp	  = ntohs(inet->inet_dport);
 	__u16 srcp	  = ntohs(inet->inet_sport);
+	__u8 state = sp->sk_state;
+	if (up->encap_rcv)
+		state |= 0xF0;
 
 	seq_printf(f, "%5d: %08X:%04X %08X:%04X"
-		" %02X %08X:%08X %02X:%08lX %08X %5d %8d %lu %d %pK %d",
-		bucket, src, srcp, dest, destp, sp->sk_state,
+		" %02X %08X:%08X %02X:%08lX %08X %5u %8d %lu %d %pK %d",
+		bucket, src, srcp, dest, destp, state,
 		sk_wmem_alloc_get(sp),
 		sk_rmem_alloc_get(sp),
 		0, 0L, 0, sock_i_uid(sp), 0, sock_i_ino(sp),


### PR DESCRIPTION
UDP IPv4 encapsulation sockets will have their state printed as 0xF0
binary ORed with the actual state such that they can be distinguished
from regular UDP sockets in /proc/net/udp.

CRs-Fixed: 821341
Change-Id: I240ab1526a4280e5e996d9577a904581684fc84a
Signed-off-by: Harout Hedeshian harouth@codeaurora.org
Signed-off-by: Shreyas Narayan shrena@codeaurora.org
